### PR TITLE
fix(deps-dev): Revert Bump semantic-release from 17.4.3 to 17.4.4 (#382)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6063,9 +6063,9 @@
       }
     },
     "marked": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.0.tgz",
-      "integrity": "sha512-KSdOTs1I/+hrQrFB+e7O/r+AorwdD4XzAi9caoRrbbkRLUS6txr1MZCZQhimm1N5Pg7A/WazC9VrYgqnwGiXMg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.3.tgz",
+      "integrity": "sha512-5otztIIcJfPc2qGTN8cVtOJEjNJZ0jwa46INMagrYfk0EvqtRuEHLsEe0LrFS0/q+ZRKT0+kXK7P2T1AN5lWRA==",
       "dev": true
     },
     "marked-terminal": {
@@ -10011,9 +10011,9 @@
       }
     },
     "semantic-release": {
-      "version": "17.4.4",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.4.4.tgz",
-      "integrity": "sha512-fQIA0lw2Sy/9+TcoM/BxyzKCSwdUd8EPRwGoOuBLgxKigPCY6kaKs8TOsgUVy6QrlTYwni2yzbMb5Q2107P9eA==",
+      "version": "17.4.3",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.4.3.tgz",
+      "integrity": "sha512-lTOUSrkbaQ+TRs3+BmtJhLtPSyiO7iTGmh5SyuEFqNO8HQbQ4nzXg4UlPrDQasO/C0eFK/V0eCbOzJdjtKBOYw==",
       "dev": true,
       "requires": {
         "@semantic-release/commit-analyzer": "^8.0.0",
@@ -10056,9 +10056,9 @@
           }
         },
         "execa": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-          "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
+          "integrity": "sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==",
           "dev": true,
           "requires": {
             "cross-spawn": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "nodemon": "^2.0.7",
     "prettier": "^2.3.1",
     "prettier-plugin-sh": "^0.6.1",
-    "semantic-release": "^17.4.4",
+    "semantic-release": "^17.4.3",
     "smee-client": "^1.1.0",
     "ts-jest": "^26.5.6",
     "typescript": "^4.3.4"


### PR DESCRIPTION
This reverts commit 4fea602b

See also: https://github.com/ti-community-infra/ti-community-bot/runs/2854706719